### PR TITLE
Added Create Categories && Paginated List Categories

### DIFF
--- a/SQL/01_Tabloid_Create_DB.sql
+++ b/SQL/01_Tabloid_Create_DB.sql
@@ -57,7 +57,9 @@ CREATE TABLE [Subscription] (
 
 CREATE TABLE [Category] (
   [Id] integer PRIMARY KEY IDENTITY,
-  [Name] nvarchar(50) NOT NULL
+  [Name] nvarchar(50) NOT NULL,
+
+  CONSTRAINT [UQ_Category_Name] UNIQUE([Name])
 )
 
 CREATE TABLE [Post] (

--- a/SQL/01_Tabloid_Create_DB.sql
+++ b/SQL/01_Tabloid_Create_DB.sql
@@ -57,9 +57,7 @@ CREATE TABLE [Subscription] (
 
 CREATE TABLE [Category] (
   [Id] integer PRIMARY KEY IDENTITY,
-  [Name] nvarchar(50) NOT NULL,
-
-  CONSTRAINT [UQ_Category_Name] UNIQUE([Name])
+  [Name] nvarchar(50) NOT NULL
 )
 
 CREATE TABLE [Post] (

--- a/SQL/03_Tabloid_UQ_Categories.sql
+++ b/SQL/03_Tabloid_UQ_Categories.sql
@@ -1,0 +1,6 @@
+use [master]
+
+GO
+
+ALTER TABLE dbo.Category 
+ADD CONSTRAINT [UQ_Category_Name] UNIQUE([Name])

--- a/SQL/03_Tabloid_UQ_Categories.sql
+++ b/SQL/03_Tabloid_UQ_Categories.sql
@@ -1,4 +1,4 @@
-use [master]
+use [Tabloid]
 
 GO
 

--- a/Tabloid/Controllers/CategoryController.cs
+++ b/Tabloid/Controllers/CategoryController.cs
@@ -24,7 +24,7 @@ namespace Tabloid.Controllers
         }
 
         [HttpGet]
-        public IActionResult Get([FromQuery] bool usePagination, [FromQuery] int? offset)
+        public IActionResult Get([FromQuery] bool usePagination, [FromQuery] int? increment, [FromQuery] int? offset)
         {
             string UUID = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
@@ -35,7 +35,7 @@ namespace Tabloid.Controllers
                 return Unauthorized();
             }
 
-            AllCategoriesDTO DTO = _categoryRepository.GetAll(usePagination, offset);
+            AllCategoriesDTO DTO = _categoryRepository.GetAll(usePagination, increment, offset);
 
             return Ok(DTO);
         }

--- a/Tabloid/Models/AllCategoriesDTO.cs
+++ b/Tabloid/Models/AllCategoriesDTO.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Tabloid.Models
+{
+    public class AllCategoriesDTO //! DTO = Data Transfer Object
+    {
+        public List<Category> Categories { get; set; }
+        public int? Total { get; set; }
+    }
+}

--- a/Tabloid/Models/Category.cs
+++ b/Tabloid/Models/Category.cs
@@ -4,7 +4,6 @@ namespace Tabloid.Models
 {
     public class Category
     {
-        [Required]
         public int Id { get; set; }
         
         [Required]

--- a/Tabloid/Repositories/CategoryRepository.cs
+++ b/Tabloid/Repositories/CategoryRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Xml.Schema;
 
 using Microsoft.Data.SqlClient;
@@ -13,7 +14,7 @@ namespace Tabloid.Repositories
     {
         public CategoryRepository(IConfiguration config) : base(config) { }
 
-        public AllCategoriesDTO GetAll(bool usePagination, int? offset)
+        public AllCategoriesDTO GetAll(bool usePagination, int? increment, int? offset)
         {
             using (SqlConnection conn = Connection)
             {
@@ -25,7 +26,7 @@ namespace Tabloid.Repositories
                         SELECT Id, [Name], (SELECT COUNT(*) FROM dbo.Category) Total
                         FROM dbo.Category
                         ORDER BY [Name]
-                        {(usePagination ? $"OFFSET {(offset == null ? 0 : offset)} ROWS FETCH NEXT 10 ROWS ONLY" : "")}
+                        {(usePagination ? $"OFFSET {(offset == null ? 0 : offset)} ROWS FETCH NEXT {(increment == null ? 10 : increment)} ROWS ONLY" : "")}
                     ";
 
                     using (SqlDataReader reader = cmd.ExecuteReader())

--- a/Tabloid/Repositories/ICategoryRepository.cs
+++ b/Tabloid/Repositories/ICategoryRepository.cs
@@ -6,6 +6,7 @@ namespace Tabloid.Repositories
 {
     public interface ICategoryRepository
     {
-        List<Category> GetAll();
+        AllCategoriesDTO GetAll(bool usePagination, int? offset);
+        public void Add(Category category);
     }
 }

--- a/Tabloid/Repositories/ICategoryRepository.cs
+++ b/Tabloid/Repositories/ICategoryRepository.cs
@@ -6,7 +6,7 @@ namespace Tabloid.Repositories
 {
     public interface ICategoryRepository
     {
-        AllCategoriesDTO GetAll(bool usePagination, int? offset);
+        AllCategoriesDTO GetAll(bool usePagination, int? increment, int? offset);
         public void Add(Category category);
     }
 }

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -19,7 +19,7 @@ export default function ApplicationViews({ isLoggedIn, role }) {
           />
           <Route path="login" element={<Login />} />
           <Route path="register" element={<Register />} />
-          
+
           <Route path="tags" >
             <Route index
               element={
@@ -33,10 +33,8 @@ export default function ApplicationViews({ isLoggedIn, role }) {
           <Route path="categories">
             <Route index
               element={
-                isLoggedIn
-                  ? role === "Admin"
-                    ? <ListCategories />
-                    : <Navigate to="/" />
+                isLoggedIn && role === "Admin"
+                  ? <ListCategories />
                   : <Navigate to="/login" />
               }
             />

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -19,15 +19,15 @@ export default function ApplicationViews({ isLoggedIn, role }) {
           <Route path="login" element={<Login />} />
           <Route path="register" element={<Register />} />
           <Route path="tags" >
-          <Route index
-          element={
-            isLoggedIn
-              ? role === "Admin"
-                ? <Tags />
-                : <Navigate to="/tags" />
-              : <Navigate to="/login" />
-          }
-          />
+            <Route index
+              element={
+                isLoggedIn
+                  ? role === "Admin"
+                    ? <Tags />
+                    : <Navigate to="/tags" />
+                  : <Navigate to="/login" />
+              }
+            />
           </Route>
 
           <Route path="categories">

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -4,6 +4,7 @@ import Login from "./Login";
 import Register from "./Register";
 import PostList from "./PostList";
 import ListCategories from "./Category/ListCategories";
+import CategoryForm from "./Category/CategoryForm";
 
 export default function ApplicationViews({ isLoggedIn, role }) {
   return (
@@ -20,13 +21,13 @@ export default function ApplicationViews({ isLoggedIn, role }) {
           <Route path="categories">
             <Route index
               element={
-                isLoggedIn
-                  ? role === "Admin"
-                    ? <ListCategories />
-                    : <Navigate to="/" />
+                isLoggedIn && role === "Admin"
+                  ? <ListCategories />
                   : <Navigate to="/login" />
               }
             />
+
+            <Route path="new" element={<CategoryForm />} />
           </Route>
 
           <Route path="*" element={<p>Whoops, nothing here...</p>} />

--- a/Tabloid/client/src/components/Category/CategoryForm.js
+++ b/Tabloid/client/src/components/Category/CategoryForm.js
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { Button, Form, FormGroup, FormText, Input, Label } from "reactstrap"
+import { addCategory } from "../../modules/categoryManager"
+
+const CategoryForm = () => {
+    const [name, setName] = useState(""),
+        navigate = useNavigate()
+
+
+    useEffect(() => {
+        document.getElementById("category-save-btn").disabled = true
+    }, [])
+
+    const changeState = (e) => {
+        if (e.target.value.trim() === "" || e.target.value === null) {
+            // Disable the save button if input is empty
+            document.getElementById("category-save-btn").disabled = true
+        } else {
+            document.getElementById("category-save-btn").disabled = false
+            setName(e.target.value)
+        }
+    }
+
+    const createCategory = (e) => {
+        e.preventDefault()
+
+        addCategory(name)
+            .then(res => {
+                if (res.ok) {
+                    navigate("/categories")
+                } else {
+                    const nameErr = document.getElementById("category-name-validation")
+                    const saveBtn = document.getElementById("category-save-btn")
+
+                    nameErr.style.display = "block"
+                    saveBtn.disabled = true
+
+                    setTimeout(() => {
+                        nameErr.style.display = "none"
+                        saveBtn.disabled = false
+                    }, 3000)
+                }
+            })
+
+    }
+
+    return (
+        <Form onSubmit={createCategory} >
+            <h2>Create Category</h2>
+            <hr className="clear" />
+            <FormGroup>
+                <Label htmlFor="name">Name</Label>
+                <Input name="name" className="w-auto" onChange={changeState} />
+                <FormText className="hidden" id="category-name-validation" color="danger">That tag already exists.</FormText>
+            </FormGroup>
+            <Button id="category-save-btn" color="success">Save</Button>
+        </Form>
+    )
+}
+
+export default CategoryForm

--- a/Tabloid/client/src/components/Category/CategoryForm.js
+++ b/Tabloid/client/src/components/Category/CategoryForm.js
@@ -52,7 +52,7 @@ const CategoryForm = () => {
             <FormGroup>
                 <Label htmlFor="name">Name</Label>
                 <Input name="name" className="w-auto" onChange={changeState} />
-                <FormText className="hidden" id="category-name-validation" color="danger">That tag already exists.</FormText>
+                <FormText className="hidden" id="category-name-validation" color="danger">An error occured.</FormText>
             </FormGroup>
             <Button id="category-save-btn" color="success">Save</Button>
         </Form>

--- a/Tabloid/client/src/components/Category/ListCategories.js
+++ b/Tabloid/client/src/components/Category/ListCategories.js
@@ -41,7 +41,11 @@ const ListCategories = () => {
                 </tbody>
             </Table>
             <Pagination total={total} increment={increment} offset={offset} setOffset={setOffset} />
-            <div>{offset + 1} - {offset + increment > total ? total : offset + increment} of {total}</div>
+            {
+                !isNaN(increment)
+                    ? <div>{offset + 1} - {offset + increment > total ? total : offset + increment} of {total}</div>
+                    : <div>{offset + 1} - {total} of {total}</div>
+            }
         </>
     )
 }

--- a/Tabloid/client/src/components/Category/ListCategories.js
+++ b/Tabloid/client/src/components/Category/ListCategories.js
@@ -1,18 +1,29 @@
 import React, { useState, useEffect } from "react"
-import { Table } from "reactstrap"
+import { useNavigate } from "react-router-dom"
+import { Button, Table } from "reactstrap"
 import { getAllCategories } from "../../modules/categoryManager"
+import Pagination from "../Partials/Pagination"
 import Category from "./Category"
 
 const ListCategories = () => {
-    const [categories, setCategories] = useState([])
+    const [categories, setCategories] = useState([]),
+        [offset, setOffset] = useState(0),
+        [total, setTotal] = useState(0),
+        [increment] = useState(10),
+        navigate = useNavigate()
 
     useEffect(() => {
-        getAllCategories().then(data => setCategories(data))
-    }, [])
+        getAllCategories(true, offset)
+            .then(data => {
+                setCategories(data.categories)
+                setTotal(data.total)
+            })
+    }, [offset])
 
     return (
         <>
             <h2>Categories</h2>
+            <Button color="primary" onClick={() => navigate("new")}>Create</Button>
             <Table>
                 <thead>
                     <tr>
@@ -21,9 +32,10 @@ const ListCategories = () => {
                     </tr>
                 </thead>
                 <tbody>
-                    {categories?.map(c => <Category cat={c} />)}
+                    {categories?.map(c => <Category key={`category--${c.id}`} cat={c} />)}
                 </tbody>
             </Table>
+            <Pagination total={total} increment={increment} offset={offset} setOffset={setOffset} />
         </>
     )
 }

--- a/Tabloid/client/src/components/Category/ListCategories.js
+++ b/Tabloid/client/src/components/Category/ListCategories.js
@@ -10,15 +10,24 @@ const ListCategories = () => {
         [offset, setOffset] = useState(0),
         [total, setTotal] = useState(0),
         [increment, setIncrement] = useState(10),
+        [usePagination, setUsePagination] = useState(true),
         navigate = useNavigate()
 
     useEffect(() => {
-        getAllCategories(true, increment, offset)
+        // If it is a number, use pagination
+        if (!isNaN(increment) && !usePagination) {
+            setUsePagination(true)
+        }
+        if (isNaN(increment) && usePagination) {
+            setUsePagination(false)
+        }
+
+        getAllCategories(usePagination, increment, offset)
             .then(data => {
                 setCategories(data.categories)
                 setTotal(data.total)
             })
-    }, [offset, increment])
+    }, [offset, increment, usePagination])
 
     return (
         <>
@@ -42,7 +51,7 @@ const ListCategories = () => {
             </Table>
             <Pagination total={total} increment={increment} offset={offset} setOffset={setOffset} />
             {
-                !isNaN(increment)
+                usePagination
                     ? <div>{offset + 1} - {offset + increment > total ? total : offset + increment} of {total}</div>
                     : <div>{offset + 1} - {total} of {total}</div>
             }

--- a/Tabloid/client/src/components/Category/ListCategories.js
+++ b/Tabloid/client/src/components/Category/ListCategories.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
 import { Button, Table } from "reactstrap"
 import { getAllCategories } from "../../modules/categoryManager"
-import Pagination from "../Partials/Pagination"
+import Pagination from "../Helpers/Pagination"
 import Category from "./Category"
 
 const ListCategories = () => {

--- a/Tabloid/client/src/components/Category/ListCategories.js
+++ b/Tabloid/client/src/components/Category/ListCategories.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
-import { Button, Table } from "reactstrap"
+import { Button, Form, Input, Label, Table } from "reactstrap"
 import { getAllCategories } from "../../modules/categoryManager"
 import Pagination from "../Helpers/Pagination"
 import Category from "./Category"
@@ -9,21 +9,26 @@ const ListCategories = () => {
     const [categories, setCategories] = useState([]),
         [offset, setOffset] = useState(0),
         [total, setTotal] = useState(0),
-        [increment] = useState(10),
+        [increment, setIncrement] = useState(10),
         navigate = useNavigate()
 
     useEffect(() => {
-        getAllCategories(true, offset)
+        getAllCategories(true, increment, offset)
             .then(data => {
                 setCategories(data.categories)
                 setTotal(data.total)
             })
-    }, [offset])
+    }, [offset, increment])
 
     return (
         <>
             <h2>Categories</h2>
             <Button color="primary" onClick={() => navigate("new")}>Create</Button>
+            <Form className="d-flex" onSubmit={(e) => { e.preventDefault(); setIncrement(parseInt(document.querySelector(`input[name="increment"]`).value)) }}>
+                <Label className="align-self-center" for="increment">Amount per page</Label>
+                <Input className="w-auto mx-2" type="number" name="increment" />
+                <Button>Update</Button>
+            </Form>
             <Table>
                 <thead>
                     <tr>
@@ -36,6 +41,7 @@ const ListCategories = () => {
                 </tbody>
             </Table>
             <Pagination total={total} increment={increment} offset={offset} setOffset={setOffset} />
+            <div>{offset + 1} - {offset + increment > total ? total : offset + increment} of {total}</div>
         </>
     )
 }

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -30,6 +30,13 @@ export default function Header({ isLoggedIn, role }) {
             }
           </Nav>
           <Nav navbar>
+            {role === "Admin" &&
+              <>
+                <NavItem>
+                  <NavLink tag={RRNavLink} to="/categories">Categories</NavLink>
+                </NavItem>
+              </>
+            }
             {isLoggedIn &&
               <>
                 <NavItem>
@@ -45,13 +52,6 @@ export default function Header({ isLoggedIn, role }) {
                 </NavItem>
                 <NavItem>
                   <NavLink tag={RRNavLink} to="/register">Register</NavLink>
-                </NavItem>
-              </>
-            }
-            {role === "Admin" &&
-              <>
-                <NavItem>
-                  <NavLink tag={RRNavLink} to="/categories">Categories</NavLink>
                 </NavItem>
               </>
             }

--- a/Tabloid/client/src/components/Helpers/Pagination.js
+++ b/Tabloid/client/src/components/Helpers/Pagination.js
@@ -1,0 +1,18 @@
+import { ButtonGroup, PaginationLink } from "reactstrap"
+
+const Pagination = ({ total, offset, increment, setOffset }) => {
+    return (
+        <ButtonGroup>
+            {
+                offset > 0 &&
+                <PaginationLink onClick={() => setOffset(offset - increment)}>Previous</PaginationLink>
+            }
+            {
+                total > offset + increment &&
+                <PaginationLink onClick={() => setOffset(offset + increment)}>Next</PaginationLink>
+            }
+        </ButtonGroup>
+    )
+}
+
+export default Pagination 

--- a/Tabloid/client/src/index.css
+++ b/Tabloid/client/src/index.css
@@ -16,3 +16,27 @@ p {
 .post p {
     white-space: pre-wrap;
 }
+
+.mr-4 {
+  margin-right: 0.25rem;
+}
+
+.mr-8 {
+  margin-right: 0.5rem;
+}
+
+.ml-4 {
+  margin-left: 0.25rem;
+}
+
+.ml-8 {
+  margin-left: 0.5rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.clear {
+  opacity: 0;
+}

--- a/Tabloid/client/src/modules/categoryManager.js
+++ b/Tabloid/client/src/modules/categoryManager.js
@@ -2,13 +2,35 @@ import { getToken } from "./authManager"
 
 const _apiUrl = "/api/category"
 
-export const getAllCategories = () => {
+// The pagination implementation is not required to use this function. If not included, it will still return the following DTO:
+/* 
+    {
+        categories: [{category}, {category}],
+        total: int?
+    }
+*/
+// usePagination (false) = fetch ALL categories at once
+// usePagination (true) = fetch ALL categories, 10 at a time, with the defined offset
+export const getAllCategories = (usePagination, offset) => {
     return getToken().then(token => {
-        return fetch(`${_apiUrl}`, {
+        return fetch(`${_apiUrl}?usePagination=${usePagination}${(offset ? `&offset=${offset}` : ``)}`, { // If offset is provided, add query 
             method: "GET",
             headers: {
                 Authorization: `Bearer ${token}`
             }
         }).then(res => res.json())
+    })
+}
+
+export const addCategory = (categoryName) => {
+    return getToken().then(token => {
+        return fetch(`${_apiUrl}`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({ name: categoryName })
+        })
     })
 }

--- a/Tabloid/client/src/modules/categoryManager.js
+++ b/Tabloid/client/src/modules/categoryManager.js
@@ -11,9 +11,10 @@ const _apiUrl = "/api/category"
 */
 // usePagination (false) = fetch ALL categories at once
 // usePagination (true) = fetch ALL categories, 10 at a time, with the defined offset
-export const getAllCategories = (usePagination, offset) => {
+export const getAllCategories = (usePagination, increment, offset) => {
     return getToken().then(token => {
-        return fetch(`${_apiUrl}?usePagination=${usePagination}${(offset ? `&offset=${offset}` : ``)}`, { // If offset is provided, add query 
+        // The query parameters are only added if an argument is provided for them
+        return fetch(`${_apiUrl}?usePagination=${usePagination}${(increment ? `&increment=${increment}` : "")}${(offset ? `&offset=${offset}` : "")}`, {
             method: "GET",
             headers: {
                 Authorization: `Bearer ${token}`


### PR DESCRIPTION
# Changes

Closes #38

- Added `pagination` helper
- Implemented pagination for Categories
- Added the ability to Create a new category
- Added a CONSTRAINT on Category to prevent duplicates

For the new CONSTRAINT, I will notify the team to run this code:
`ALTER TABLE dbo.Category ADD CONSTRAINT [UQ_Category_Name] UNIQUE([Name])`

# Testing

1) Logged in as admin and author, trying to access the endpoints from each role.
2) Tested for edge-cases in creating categories (empty string, null string, duplicate values)
3) Checked that the Create Category form has proper error handling and success functionality (redirects to ListCategories)
4) Confirmed that the pagination works properly by clicking the NEXT and PREVIOUS buttons when presented with them multiple times.
4a) Also tested the pagination from as little as 2 categories to as much as 30
5) Tested after the merging that no functionality was lost