### PR TITLE
admin can now reactivate deactivated users

### DIFF
--- a/Tabloid/client/src/components/user/ListUsers.js
+++ b/Tabloid/client/src/components/user/ListUsers.js
@@ -7,12 +7,17 @@ import User from "./User";
 
 const ListUsers = () => {
     const [users, setUsers] = useState([]);
+    const [showDeactivated, setShowDeactivated] = useState(false);
 
-    useEffect(() => {
+    const getUsers = () => {
         getAllUserProfiles()
             .then(usersData => {
                 setUsers(usersData)
             })
+    }
+
+    useEffect(() => {
+        getUsers();
     }, []);
 
     return (
@@ -23,11 +28,19 @@ const ListUsers = () => {
                         <th>Display Name</th>
                         <th>Name</th>
                         <th>User Type</th>
+                        <th>{
+                            showDeactivated ? <button onClick={() => { setShowDeactivated(false) }}>View Activated</button>
+                                : <button onClick={() => { setShowDeactivated(true) }}>View Deactivated</button>
+                        }</th>
                     </tr>
                 </thead>
                 <tbody>
                     {
-                        users.map(user => <User key={user.id} user={user} />)
+                        users.map(user => {
+                            if (!showDeactivated === user.activated) {
+                                return <User key={user.id} user={user} getUsers={getUsers} />
+                            }
+                        })
                     }
                 </tbody>
             </Table>

--- a/Tabloid/client/src/components/user/User.js
+++ b/Tabloid/client/src/components/user/User.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { updateUserProfile } from "../../modules/userProfileManager";
 
 
-const User = ({ user }) => {
+const User = ({ user, getUsers }) => {
     const [displayDeactivateButton, setDisplayDeactivateButton] = useState(true)
 
     const handleDeactivate = (event) => {
@@ -11,6 +11,14 @@ const User = ({ user }) => {
         user.activated = false;
         updateUserProfile(user);
         setDisplayDeactivateButton(true);
+        getUsers();
+    }
+
+    const handleReactivate = (event) => {
+        event.preventDefault();
+        user.activated = true;
+        updateUserProfile(user);
+        getUsers();
     }
 
     if (user.activated) {
@@ -27,6 +35,7 @@ const User = ({ user }) => {
             <td><Link to={`${user.id}`}>{user.displayName}</Link></td>
             <td>{user.fullName}</td>
             <td>{user.userType.name}</td>
+            <td><button onClick={handleReactivate}>Reactivate</button></td>
         </tr>
     }
 


### PR DESCRIPTION
closes #22 

When viewing list of users, an admin will now only see activated users, but can click the Show Deactivated button to see deactivated users, and then toggle back with the Show Activated button.  When viewing deactivated users, can select the Reactivate button next to a user to reactivate them, allowing them to log in again.

Tested by deactivating user then reactivating and attempting to log in.